### PR TITLE
Substituição de imagem antiga por imagem nova no sistema de arquivos

### DIFF
--- a/laudai/src/main/java/br/com/laudai/domain/service/ImagemLocalStorageService.java
+++ b/laudai/src/main/java/br/com/laudai/domain/service/ImagemLocalStorageService.java
@@ -28,6 +28,19 @@ public class ImagemLocalStorageService implements ImagemStorageService{
 
     }
 
+    @Override
+    public void remover(String nomeArquivo) {
+
+        Path path = getArquivoPath(nomeArquivo);
+
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            throw new RuntimeException("Não foi possível excluir o arquivo.");
+        }
+
+    }
+
     private Path getArquivoPath(String nomeArquivo) {
         return localDirectory.resolve(Path.of(nomeArquivo));
     }

--- a/laudai/src/main/java/br/com/laudai/domain/service/ImagemStorageService.java
+++ b/laudai/src/main/java/br/com/laudai/domain/service/ImagemStorageService.java
@@ -6,4 +6,14 @@ public interface ImagemStorageService {
 
     void armazenar( String nomeArquivo, InputStream inputStream);
 
+    void remover(String nomeArquivo);
+
+    default void substituir(String nomeArquivoAntigo, String nomeArquivoNovo, InputStream inputStreamArquivoNovo){
+        this.armazenar(nomeArquivoNovo, inputStreamArquivoNovo);
+
+        if(nomeArquivoAntigo != null) {
+            this.remover(nomeArquivoAntigo);
+        }
+    }
+
 }

--- a/laudai/src/main/java/br/com/laudai/domain/service/ResultadoExameServiceImpl.java
+++ b/laudai/src/main/java/br/com/laudai/domain/service/ResultadoExameServiceImpl.java
@@ -43,6 +43,7 @@ public class ResultadoExameServiceImpl implements ResultadoExameService {
             // Se já tem uma imagem, eu atualizo a imagem que já estava persistida.
             log.info("Já tem uma imagem!");
             log.info(consulta.getResultadoExame().getImagemExame().toString());
+            String nomeArquivoAntigo = consulta.getResultadoExame().getImagemExame().getNomeArquivo();
 
             Integer id = consulta.getResultadoExame().getImagemExame().getId();
             imagemExame.setId(id);
@@ -53,7 +54,9 @@ public class ResultadoExameServiceImpl implements ResultadoExameService {
 
             log.info(consulta.getResultadoExame().getImagemExame().toString());
 
-            imagemStorageService.armazenar(imagemExame.getNomeArquivo(), inputStream);
+
+            imagemStorageService.substituir(nomeArquivoAntigo, imagemExame.getNomeArquivo(), inputStream);
+
             return imagemExame;
 
         }


### PR DESCRIPTION
Se a imagem de um resultadoexame for atualizada, a imagem antiga é removida do sistema de arquivos para dar espaço para a imagem nova.